### PR TITLE
Use undefined instead of null

### DIFF
--- a/src/nothing.js
+++ b/src/nothing.js
@@ -1,5 +1,5 @@
 function nothing() {
-    return null;
+    return undefined;
 }
 
 module.exports = nothing;


### PR DESCRIPTION
[By definition](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null), `null` is a value and it exists, where `typeof null` equals `'object'`. I think the library should better return `undefined`, which has truly no value.